### PR TITLE
Fix: Hotspot Index Out-of-Bounds Error in Nanobody Sampling

### DIFF
--- a/sample_antibody_nanobody.py
+++ b/sample_antibody_nanobody.py
@@ -367,6 +367,12 @@ def process_file(
     metadata["modeled_seq_len"] = len(modeled_idx)
     complex_feats["modeled_idx"] = modeled_idx
 
+    # zf_fixed: Map hotspot indices to modeled_idx space
+    idx_mapping = {old_idx: new_idx for new_idx, old_idx in enumerate(modeled_idx)}
+    modeled_hotspot_index = [idx_mapping[idx] for idx in hotspot_index if idx in idx_mapping]
+    metadata["hotspots"] = modeled_hotspot_index
+
+
     # Set chain groups for antigen and binder
     antigen_chains = [
         du.chain_str_to_int(chain_id)


### PR DESCRIPTION
Problem:
- hotspot_index was calculated on the full structure (including non-standard residues)
- Data is later filtered by modeled_idx (keeping only standard amino acids)
- Saved hotspot indices were not mapped to the filtered space
- This caused IndexError when indices exceeded the filtered array size

Example:
- Original structure: 196 residues
- After filtering: 188 residues (modeled_seq_len)
- Hotspot indices: [146, 157, 173, 179] (based on original structure)
- Error: index 179 > 188, out of bounds

Solution:
Map hotspot indices to the modeled_idx space before saving to metadata.